### PR TITLE
add more device properties

### DIFF
--- a/custom_components/livisi/__init__.py
+++ b/custom_components/livisi/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import aiohttp_client, device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
 from .aiolivisi import AioLivisi
-from .const import DOMAIN, LOGGER, CAPABILITY_MAP, SWITCH_DEVICE_TYPES
+from .const import CONF_HOST, DOMAIN, LOGGER, CAPABILITY_MAP, SWITCH_DEVICE_TYPES
 from .coordinator import LivisiDataUpdateCoordinator
 
 
@@ -45,8 +45,11 @@ async def async_setup_entry(hass: core.HomeAssistant, entry: ConfigEntry) -> boo
     device_registry.async_get_or_create(
         config_entry_id=coordinator.serial_number,
         identifiers={(DOMAIN, entry.entry_id)},
+        model=f"SHC {coordinator.controller_type}",
+        sw_version=coordinator.os_version,
         manufacturer="Livisi",
         name=f"SHC {coordinator.controller_type} {coordinator.serial_number}",
+        configuration_url=f"http://{entry.data[CONF_HOST]}",
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/livisi/coordinator.py
+++ b/custom_components/livisi/coordinator.py
@@ -60,6 +60,7 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
         self.capability_to_device: dict[str, str] = {}
         self.rooms: dict[str, Any] = {}
         self.serial_number: str = ""
+        self.os_version: str = ""
         self.controller_type: str = ""
         self.is_avatar: bool = False
         self.port: int = 0
@@ -108,6 +109,7 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[dict[str, Any]]]):
             self.is_avatar = False
         self.controller_type = controller_type
         self.serial_number = controller_data["serialNumber"]
+        self.os_version = controller_data["osVersion"]
 
     async def async_get_devices(self) -> list[dict[str, Any]]:
         """Set the discovered devices list."""

--- a/custom_components/livisi/entity.py
+++ b/custom_components/livisi/entity.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.binary_sensor import BinarySensorEntity
 
-from .const import CAPABILITY_MAP, DOMAIN, LIVISI_REACHABILITY_CHANGE
+from .const import CAPABILITY_MAP, CONF_HOST, DOMAIN, LIVISI_REACHABILITY_CHANGE
 from .coordinator import LivisiDataUpdateCoordinator
 
 
@@ -74,8 +74,10 @@ class LivisiEntity(CoordinatorEntity[LivisiDataUpdateCoordinator]):
             identifiers={(DOMAIN, device_id)},
             manufacturer=device["manufacturer"],
             model=device["type"],
+            sw_version=device["version"],
             name=device_name,
             suggested_area=room_name,
+            configuration_url=f"http://{config_entry.data[CONF_HOST]}/#/device/{device['id']}",
             via_device=(DOMAIN, config_entry.entry_id),
         )
         super().__init__(coordinator)


### PR DESCRIPTION
From my PR at the to the hassio repository. 
I added a link to the local livisi web page for the SHC and the devices (although it does not seem to redirect to the appropriate device directly, as ~~there seems to be kind of CSRF protection `?k=abdcef` in the URL~~ the login flow does not support multiple tabs without reauthentication) 
![image](https://github.com/planbnet/livisi_unofficial/assets/13590797/78969992-9c5d-4c6b-a03b-ed26bc35f9ea)
![image](https://github.com/planbnet/livisi_unofficial/assets/13590797/f6e24c4a-0e31-41d3-ad54-199345d212c7)

As well as the software version numbers.