### PR TITLE
Add binary motion sensor

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -17,7 +17,8 @@
                 "ms-python.python",
                 "github.vscode-pull-request-github",
                 "ryanluker.vscode-coverage-gutters",
-                "ms-python.vscode-pylance"
+                "ms-python.vscode-pylance",
+                "ms-python.black-formatter"
             ],
             "settings": {
                 "files.eol": "\n",

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,9 @@ __pycache__
 
 # misc
 .coverage
-.vscode
+.vscode/*
+!.vscode/tasks.json
+!.vscode/launch.json
 coverage.xml
 .ruff_cache
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Home Assistant",
+      "type": "python",
+      "request": "launch",
+      "module": "homeassistant",
+      "justMyCode": false,
+      "args": ["--debug", "-c", "config"],
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -49,3 +49,14 @@ All configuration in done in the UI. See the [official documentation](https://ww
 * Luminance is provided in percent by Livisi. Currently we get a warning: `<LivisiSensor> is using native unit of measurement '%' which is not a valid unit for the device class ('illuminance') it is using; expected one of ['lx']` but as percent is the correct unit here, I don't think we should change it (at least until it causes problems in HA)
 
 * Home Assistant requires all communication to the service backend to be handled by a library (as it was done with the original, unmaintained aiolivisi lib). This prevents the merge of this library to the official core code base currently. However, I don't feel it makes sense to move the code to a seperately maintained library as it is only used here and additions often need to happen along the whole code path. Semantically such a split makes sense though, so to make a later separation possible, I added the `livisi_` prefix to all the "library" code.
+
+
+## Development
+
+1. Clone this repository and open it in a devcontainer.
+2. `cd scripts`
+3. Only run the first time or on updates: `./setup`
+4. `./develop`
+
+You can also use the VSCode launch configuration `Home Assistant`.
+

--- a/custom_components/livisi/__init__.py
+++ b/custom_components/livisi/__init__.py
@@ -25,6 +25,7 @@ PLATFORMS: Final = [
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.LIGHT,
+    Platform.NUMBER,
 ]
 
 

--- a/custom_components/livisi/binary_sensor.py
+++ b/custom_components/livisi/binary_sensor.py
@@ -19,7 +19,7 @@ from homeassistant.helpers import event as evt
 from homeassistant.const import Platform
 
 from .livisi_device import LivisiDevice
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 
 from .const import (
     BATTERY_POWERED_DEVICES,
@@ -214,7 +214,9 @@ class LivisiMotionSensor(LivisiEntity, BinarySensorEntity):
 
         self._delay_listener: CALLBACK_TYPE | None = None
         # TODO: Use static variables
-        self.off_delay_entity_id: str = device.name + "_duration"
+        self.off_delay_entity_id: str = (
+            Platform.NUMBER + "." + device.name + "_duration"
+        )
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
@@ -239,8 +241,9 @@ class LivisiMotionSensor(LivisiEntity, BinarySensorEntity):
             off_delay = self.get_off_delay()
             lastactive = datetime.fromisoformat(response)
             now = datetime.now(timezone.utc)
-            remaining_detected_time = now - lastactive - off_delay
-            if remaining_detected_time > 0:
+            delta = now - lastactive
+
+            if delta.seconds < off_delay:
                 self._attr_is_on = True
 
                 @callback
@@ -250,6 +253,7 @@ class LivisiMotionSensor(LivisiEntity, BinarySensorEntity):
                     self._attr_is_on = False
                     self.async_write_ha_state()
 
+                remaining_detected_time = off_delay - delta.seconds
                 self._delay_listener = evt.async_call_later(
                     self.hass, remaining_detected_time, off_delay_listener
                 )
@@ -283,6 +287,9 @@ class LivisiMotionSensor(LivisiEntity, BinarySensorEntity):
             )
 
     def get_off_delay(self) -> float:
-        """Get the Delay"""
-        id = Platform.NUMBER + "." + self.off_delay_entity_id
-        return float(self.hass.states.get(id).state)
+        """Get the Delay."""
+        id = self.off_delay_entity_id
+        state = self.hass.states.get(id)
+        if state is None:
+            return None
+        return float(state.state)

--- a/custom_components/livisi/binary_sensor.py
+++ b/custom_components/livisi/binary_sensor.py
@@ -1,6 +1,8 @@
 """Code to handle a Livisi Binary Sensor."""
 from __future__ import annotations
 
+from typing import Any
+
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -12,8 +14,12 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.core import CALLBACK_TYPE
+from homeassistant.helpers import event as evt
+from homeassistant.const import Platform
 
 from .livisi_device import LivisiDevice
+from datetime import datetime, timezone, timedelta
 
 from .const import (
     BATTERY_POWERED_DEVICES,
@@ -22,6 +28,8 @@ from .const import (
     IS_SMOKE_ALARM,
     LIVISI_STATE_CHANGE,
     LOGGER,
+    LIVISI_EVENT,
+    MOTION_DEVICE_TYPES,
     WDS_DEVICE_TYPES,
     SMOKE_DETECTOR_DEVICE_TYPES,
 )
@@ -89,7 +97,20 @@ async def async_setup_entry(
                     LOGGER.debug("Include battery sensor for: %s", device.type)
                     coordinator.devices.add(device.id)
                     entities.append(livisi_binary)
-
+                if device.type in MOTION_DEVICE_TYPES:
+                    livisi_motion: BinarySensorEntity = LivisiMotionSensor(
+                        config_entry,
+                        coordinator,
+                        device,
+                        BinarySensorEntityDescription(
+                            key="motionDetectedCount",
+                            device_class=BinarySensorDeviceClass.MOTION,
+                        ),
+                        capability_name="MotionDetectionSensor",
+                    )
+                    LOGGER.debug("Include motion sensor device type: %s", device.type)
+                    coordinator.devices.add(device.id)
+                    entities.append(livisi_motion)
         async_add_entities(entities)
 
     config_entry.async_on_unload(
@@ -171,3 +192,97 @@ class LivisiBatteryLowSensor(LivisiEntity, BinarySensorEntity):
 
         if device is not None:
             self._attr_is_on = device.battery_low
+
+
+class LivisiMotionSensor(LivisiEntity, BinarySensorEntity):
+    """Represents a Livisi Motion Sensor."""
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        coordinator: LivisiDataUpdateCoordinator,
+        device: LivisiDevice,
+        entity_desc: BinarySensorEntityDescription,
+        capability_name: str,
+    ) -> None:
+        """Initialize the Livisi sensor."""
+        super().__init__(config_entry, coordinator, device, capability_name)
+        self.entity_description = entity_desc
+        self._attr_device_class: BinarySensorDeviceClass = (
+            BinarySensorDeviceClass.MOTION
+        )
+
+        self._delay_listener: CALLBACK_TYPE | None = None
+        # TODO: Use static variables
+        self.off_delay_entity_id: str = device.name + "_duration"
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        await super().async_added_to_hass()
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{LIVISI_EVENT}_{self.capability_id}",
+                self.trigger_event,
+            )
+        )
+
+        response = await self.coordinator.aiolivisi.async_get_device_state(
+            self.capability_id, self.entity_description.key, "lastChanged"
+        )
+        if response is None:
+            self.update_reachability(False)
+        else:
+            self.update_reachability(True)
+
+            off_delay = self.get_off_delay()
+            lastactive = datetime.fromisoformat(response)
+            now = datetime.now(timezone.utc)
+            remaining_detected_time = now - lastactive - off_delay
+            if remaining_detected_time > 0:
+                self._attr_is_on = True
+
+                @callback
+                def off_delay_listener(now: Any) -> None:
+                    """Switch device off after a delay."""
+                    self._delay_listener = None
+                    self._attr_is_on = False
+                    self.async_write_ha_state()
+
+                self._delay_listener = evt.async_call_later(
+                    self.hass, remaining_detected_time, off_delay_listener
+                )
+            else:
+                self._attr_is_on = False
+
+    @callback
+    def trigger_event(self, event_data: Any) -> None:
+        """Update the state of the device."""
+        self._attr_is_on = True
+        self.async_write_ha_state()
+
+        # From this example:
+        # https://github.com/home-assistant/core/blob/dev/homeassistant/components/rfxtrx/binary_sensor.py#L21
+        if self._delay_listener:
+            self._delay_listener()
+            self._delay_listener = None
+
+        off_delay = self.get_off_delay()
+        if self.is_on and off_delay is not None:
+
+            @callback
+            def off_delay_listener(now: Any) -> None:
+                """Switch device off after a delay."""
+                self._delay_listener = None
+                self._attr_is_on = False
+                self.async_write_ha_state()
+
+            self._delay_listener = evt.async_call_later(
+                self.hass, off_delay, off_delay_listener
+            )
+
+    def get_off_delay(self) -> float:
+        """Get the Delay"""
+        id = Platform.NUMBER + "." + self.off_delay_entity_id
+        return float(self.hass.states.get(id).state)

--- a/custom_components/livisi/livisi_connector.py
+++ b/custom_components/livisi/livisi_connector.py
@@ -274,19 +274,22 @@ class LivisiConnection:
 
         return devicelist
 
-    async def async_get_device_state(self, capability: str, key: str) -> Any | None:
+    async def async_get_device_state(
+        self, capability: str, key: str, valueKey: str = "value"
+    ) -> Any | None:
         """Get state of the device."""
+        requestUrl = f"capability/{capability}/state"
         try:
-            response = await self.async_send_authorized_request(
-                "get", f"capability/{capability}/state"
-            )
+            response = await self.async_send_authorized_request("get", requestUrl)
             if response is None:
                 return None
             if not isinstance(response, dict):
                 return None
-            return response.get(key, {}).get("value")
+            return response.get(key, {}).get(valueKey, None)
         except Exception:
-            LOGGER.warning("Error getting device state", exc_info=True)
+            LOGGER.warning(
+                f"Error getting device state (url: {requestUrl})", exc_info=True
+            )
             return None
 
     async def async_set_state(

--- a/custom_components/livisi/number.py
+++ b/custom_components/livisi/number.py
@@ -1,0 +1,115 @@
+"""Code to handle a Livisi Number Sensor."""
+from __future__ import annotations
+
+
+from homeassistant.components.number import NumberEntity, NumberEntityDescription
+from homeassistant.components.number import RestoreNumber
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.const import (
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.helpers.entity import DeviceInfo
+
+
+from .livisi_device import LivisiDevice
+
+from .const import CONF_HOST, DOMAIN, LOGGER, MOTION_DEVICE_TYPES
+from .coordinator import LivisiDataUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up number entities."""
+    coordinator: LivisiDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    known_devices = set()
+
+    @callback
+    def handle_coordinator_update() -> None:
+        """Add Motion Sensor Config Entities."""
+        shc_devices: list[LivisiDevice] = coordinator.data
+
+        entities: list[NumberEntity] = []
+        for device in shc_devices:
+            if device.id not in known_devices:
+                known_devices.add(device.id)
+                if device.type in MOTION_DEVICE_TYPES:
+                    livisi_motion_duration: NumberEntity = NoopConfigNumber(
+                        config_entry,
+                        device,
+                        NumberEntityDescription(
+                            key=device.name + "_duration",
+                            name="Duration",
+                            entity_category=EntityCategory.CONFIG,
+                            native_max_value=65535,
+                            native_min_value=0,
+                            native_step=1,
+                            native_unit_of_measurement="s",
+                        ),
+                    )
+                    LOGGER.debug("Include number sensor device type: %s", device.type)
+                    coordinator.devices.add(device.id)
+                    entities.append(livisi_motion_duration)
+        async_add_entities(entities)
+
+    config_entry.async_on_unload(
+        coordinator.async_add_listener(handle_coordinator_update)
+    )
+
+
+class NoopConfigNumber(RestoreNumber):
+    """Represents a NumberEntity without effects on the livisi system (for internal use)."""
+
+    _attr_has_entity_name = True
+
+    number: float | None = 20
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        device: LivisiDevice,
+        entity_desc: NumberEntityDescription,
+    ) -> None:
+        """Initialize the Livisi sensor."""
+        self.entity_description = entity_desc
+        unique_id = device.id + "_" + entity_desc.key + "_number"
+        self._attr_unique_id = unique_id
+        self.device_id = device.id
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, device.id)},
+            manufacturer=device.manufacturer,
+            model=device.type,
+            sw_version=device.version,
+            name=device.name,
+            suggested_area=device.room,
+            configuration_url=f"http://{config_entry.data[CONF_HOST]}/#/device/{device.id}",
+            via_device=(DOMAIN, config_entry.entry_id),
+        )
+        super().__init__()
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last state."""
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) and (
+            last_number_data := await self.async_get_last_number_data()
+        ):
+            if last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+                self.number = last_number_data.native_value
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the value of the sensor property."""
+        return self.number
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set sensor config."""
+        self.number = value
+

--- a/custom_components/livisi/translations/de.json
+++ b/custom_components/livisi/translations/de.json
@@ -43,6 +43,11 @@
             "luminance": {
                 "name": "Helligkeit"
             }
+        },
+        "number": {
+            "duration": {
+                "name": "Auslösedauer"
+            }
         }
     }
 }

--- a/custom_components/livisi/translations/en.json
+++ b/custom_components/livisi/translations/en.json
@@ -43,6 +43,11 @@
             "luminance": {
                 "name": "Luminance"
             }
+        },
+        "number": {
+            "duration": {
+                "name": "Duration"
+            }
         }
     }
 }


### PR DESCRIPTION
I also had a more pressing issue than #62, so here you go: 

The motion sensors now has a binary sensor which is automatically cleared after a configurable amount of time.
![motion_detected](https://github.com/planbnet/livisi_unofficial/assets/13590797/9bdfa8a3-02cb-4226-b1c7-c922368a16fd)

Only tested with `WMD` device type.