### PR TITLE
fix sensors keep unavailable state

### DIFF
--- a/custom_components/livisi/binary_sensor.py
+++ b/custom_components/livisi/binary_sensor.py
@@ -141,7 +141,7 @@ class LivisiBinarySensor(LivisiEntity, BinarySensorEntity):
         """Update the state of the device."""
         if not isinstance(state, bool):
             return
-        self._attr_available = True
+        self.update_reachability(True)
         self._attr_is_on = state
         self.async_write_ha_state()
 

--- a/custom_components/livisi/binary_sensor.py
+++ b/custom_components/livisi/binary_sensor.py
@@ -141,6 +141,7 @@ class LivisiBinarySensor(LivisiEntity, BinarySensorEntity):
         """Update the state of the device."""
         if not isinstance(state, bool):
             return
+        self._attr_available = True
         self._attr_is_on = state
         self.async_write_ha_state()
 

--- a/custom_components/livisi/climate.py
+++ b/custom_components/livisi/climate.py
@@ -242,18 +242,21 @@ class LivisiClimate(LivisiEntity, ClimateEntity):
     def update_target_temperature(self, target_temperature: float) -> None:
         """Update the target temperature of the climate device."""
         self._attr_target_temperature = target_temperature
+        self.update_reachability(True)
         self.async_write_ha_state()
 
     @callback
     def update_temperature(self, current_temperature: float) -> None:
         """Update the current temperature of the climate device."""
         self._attr_current_temperature = current_temperature
+        self.update_reachability(True)
         self.async_write_ha_state()
 
     @callback
     def update_humidity(self, humidity: int) -> None:
         """Update the humidity of the climate device."""
         self._attr_current_humidity = humidity
+        self.update_reachability(True)
         self.async_write_ha_state()
 
     @callback

--- a/custom_components/livisi/const.py
+++ b/custom_components/livisi/const.py
@@ -60,6 +60,24 @@ HUMIDITY: Final = "humidity"
 CAPABILITY_POWER_SENSOR: Final = "PowerConsumptionSensor"
 POWER_CONSUMPTION: Final = "powerConsumptionWatt"
 
+#
+# Type: "TwoWayMeter"
+# Capabilites:
+# TwoWayMeterPowerConsumptionSensor
+#   "properties": {"powerInWatt": 58}
+# TwoWayMeterEnergyFeedSensor
+#   "properties": {"energyPerDayInKWh": 0.003,"totalEnergy": 60682.68}
+# TwoWayMeterEnergyConsumptionSensor
+#   "properties": {"energyPerDayInKWh": 4.775,"energyPerMonthInKWh": 152.721,"totalEnergy": 23386.434}
+
+# Type: "GenerationMeter"
+# Capabilites:
+# GenerationMeterPowerConsumptionSensor
+#   "properties": {"powerInWatt": 847},
+# GenerationMeterEnergySensor
+#   "properties": {"energyPerDayInKWh": 1.257,"energyPerMonthInKWh": 297.583,"totalEnergy": 107317.164}
+
+
 ON_STATE: Final = "onState"
 SHUTTER_LEVEL: Final = "shutterLevel"
 DIM_LEVEL: Final = "dimLevel"

--- a/custom_components/livisi/sensor.py
+++ b/custom_components/livisi/sensor.py
@@ -365,6 +365,7 @@ class LivisiSensor(LivisiEntity, SensorEntity):
     @callback
     def update_states(self, state: Decimal) -> None:
         """Update the state of the device."""
+        self.update_reachability(True)
         self._attr_native_value = self.convert_to_hass(state)
         self.async_write_ha_state()
 


### PR DESCRIPTION
Because the entity `_attr_available` is set to false when the plugin is loaded subsequent updates (when a window is opened or closed) are not visible as the property is not set back to `true`. 
This resolves the issue by updating it too. 

This is a fix for the problem I mentioned in #92 