### PR TITLE
Fix integration startup when data unavailable

### DIFF
--- a/custom_components/livisi/__init__.py
+++ b/custom_components/livisi/__init__.py
@@ -61,7 +61,11 @@ async def async_setup_entry(hass: core.HomeAssistant, entry: ConfigEntry) -> boo
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    await coordinator.async_config_entry_first_refresh()
+    try:
+        await coordinator.async_config_entry_first_refresh()
+    except Exception as exception:
+        LOGGER.error("Initial data refresh failed: %s", exception, exc_info=True)
+        raise ConfigEntryNotReady(exception) from exception
 
     LOGGER.debug(coordinator.data)
 

--- a/custom_components/livisi/binary_sensor.py
+++ b/custom_components/livisi/binary_sensor.py
@@ -51,7 +51,9 @@ async def async_setup_entry(
     @callback
     def handle_coordinator_update() -> None:
         """Add Window Sensor."""
-        shc_devices: list[LivisiDevice] = coordinator.data
+        shc_devices: list[LivisiDevice] | None = coordinator.data
+        if shc_devices is None:
+            return
         entities: list[BinarySensorEntity] = []
         for device in shc_devices:
             if device.id not in known_devices:
@@ -186,14 +188,17 @@ class LivisiBatteryLowSensor(LivisiEntity, BinarySensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        device = next(
-            (
-                device
-                for device in self.coordinator.data
-                if device.id + "_battery" == self.unique_id
-            ),
-            None,
-        )
+        devices = self.coordinator.data
+        device = None
+        if devices is not None:
+            device = next(
+                (
+                    dev
+                    for dev in devices
+                    if dev.id + "_battery" == self.unique_id
+                ),
+                None,
+            )
 
         if device is not None:
             self._attr_is_on = device.battery_low

--- a/custom_components/livisi/button.py
+++ b/custom_components/livisi/button.py
@@ -37,7 +37,9 @@ async def async_setup_entry(
     @callback
     def handle_coordinator_update() -> None:
         """Add button."""
-        shc_devices: list[LivisiDevice] = coordinator.data
+        shc_devices: list[LivisiDevice] | None = coordinator.data
+        if shc_devices is None:
+            return
         entities: list[ButtonEntity] = []
         for device in shc_devices:
             if device.id not in known_devices:

--- a/custom_components/livisi/climate.py
+++ b/custom_components/livisi/climate.py
@@ -49,7 +49,9 @@ async def async_setup_entry(
     @callback
     def handle_coordinator_update() -> None:
         """Add climate device."""
-        shc_devices: list[LivisiDevice] = coordinator.data
+        shc_devices: list[LivisiDevice] | None = coordinator.data
+        if shc_devices is None:
+            return
         entities: list[ClimateEntity] = []
         for device in shc_devices:
             if device.type in VRCC_DEVICE_TYPES and device.id not in known_devices:

--- a/custom_components/livisi/cover.py
+++ b/custom_components/livisi/cover.py
@@ -41,7 +41,9 @@ async def async_setup_entry(
     @callback
     def handle_coordinator_update() -> None:
         """Add cover."""
-        shc_devices: list[LivisiDevice] = coordinator.data
+        shc_devices: list[LivisiDevice] | None = coordinator.data
+        if shc_devices is None:
+            return
         entities: list[CoverEntity] = []
         for device in shc_devices:
             if device.type in SHUTTER_DEVICE_TYPES and device.id not in known_devices:

--- a/custom_components/livisi/event.py
+++ b/custom_components/livisi/event.py
@@ -39,7 +39,9 @@ async def async_setup_entry(
     @callback
     def handle_coordinator_update() -> None:
         """Add events."""
-        shc_devices: list[LivisiDevice] = coordinator.data
+        shc_devices: list[LivisiDevice] | None = coordinator.data
+        if shc_devices is None:
+            return
         entities: list[EventEntity] = []
         for device in shc_devices:
             if device.id not in known_devices:

--- a/custom_components/livisi/light.py
+++ b/custom_components/livisi/light.py
@@ -39,7 +39,9 @@ async def async_setup_entry(
     @callback
     def handle_coordinator_update() -> None:
         """Add light."""
-        shc_devices: list[LivisiDevice] = coordinator.data
+        shc_devices: list[LivisiDevice] | None = coordinator.data
+        if shc_devices is None:
+            return
         entities: list[LightEntity] = []
         for device in shc_devices:
             if device.id not in known_devices:

--- a/custom_components/livisi/number.py
+++ b/custom_components/livisi/number.py
@@ -31,7 +31,9 @@ async def async_setup_entry(
     @callback
     def handle_coordinator_update() -> None:
         """Add Motion Sensor Config Entities."""
-        shc_devices: list[LivisiDevice] = coordinator.data
+        shc_devices: list[LivisiDevice] | None = coordinator.data
+        if shc_devices is None:
+            return
 
         entities: list[NumberEntity] = []
         for device in shc_devices:

--- a/custom_components/livisi/sensor.py
+++ b/custom_components/livisi/sensor.py
@@ -237,7 +237,9 @@ async def async_setup_entry(
     @callback
     def handle_coordinator_update() -> None:
         """Add Sensors."""
-        shc_devices: list[LivisiDevice] = coordinator.data
+        shc_devices: list[LivisiDevice] | None = coordinator.data
+        if shc_devices is None:
+            return
         entities: list[SensorEntity] = []
         for device in shc_devices:
             if device.id not in known_devices:
@@ -397,7 +399,9 @@ class LivisiControllerSensor(LivisiEntity, SensorEntity):
     @property
     def native_value(self):
         """Return the state of the sensor."""
-        shc_devices: list[LivisiDevice] = self.coordinator.data
+        shc_devices: list[LivisiDevice] | None = self.coordinator.data
+        if shc_devices is None:
+            return None
         for device in shc_devices:
             if device.is_shc:
                 return device.state.get(self.entity_description.key, {}).get(

--- a/custom_components/livisi/siren.py
+++ b/custom_components/livisi/siren.py
@@ -39,7 +39,9 @@ async def async_setup_entry(
     @callback
     def handle_coordinator_update() -> None:
         """Add switch."""
-        shc_devices: list[LivisiDevice] = coordinator.data
+        shc_devices: list[LivisiDevice] | None = coordinator.data
+        if shc_devices is None:
+            return
         entities: list[SirenEntity] = []
         for device in shc_devices:
             if (

--- a/custom_components/livisi/switch.py
+++ b/custom_components/livisi/switch.py
@@ -38,7 +38,9 @@ async def async_setup_entry(
     @callback
     def handle_coordinator_update() -> None:
         """Add switch."""
-        shc_devices: list[LivisiDevice] = coordinator.data
+        shc_devices: list[LivisiDevice] | None = coordinator.data
+        if shc_devices is None:
+            return
         entities: list[SwitchEntity] = []
         for device in shc_devices:
             if device.id not in known_devices:


### PR DESCRIPTION
## Summary
- avoid iterating over `None` data in `handle_coordinator_update`
- check for missing coordinator data in entity initialization and property methods
- retry initial refresh by catching errors when coordinator data is unavailable

## Testing
- `scripts/lint`
