### PR TITLE
Fix token refresh error handling

### DIFF
--- a/custom_components/livisi/coordinator.py
+++ b/custom_components/livisi/coordinator.py
@@ -220,7 +220,8 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[LivisiDevice]]):
             self.websocket_connected = False
 
             # if homeassistant is shutting down, we don't want to reconnect
-            if self.shutdown:
+            if self.shutdown or self.hass.is_stopping:
+                self._reconnect_attempts = 0
                 LOGGER.info("Livisi WebSocket loop stopped due to shutdown.")
                 return
 

--- a/custom_components/livisi/coordinator.py
+++ b/custom_components/livisi/coordinator.py
@@ -175,7 +175,7 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[LivisiDevice]]):
 
     async def on_websocket_close(self) -> None:
         """Log WebSocket close."""
-        LOGGER.warning("Livisi WebSocket connection closed by server.")
+        LOGGER.debug("Livisi WebSocket on close handler called.")
 
     # ---------------------------------------------------------------------
     # WebSocket management
@@ -218,8 +218,13 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[LivisiDevice]]):
 
             # At this point the connection is gone
             self.websocket_connected = False
-            self._reconnect_attempts += 1
 
+            # if homeassistant is shutting down, we don't want to reconnect
+            if self.shutdown:
+                LOGGER.info("Livisi WebSocket loop stopped due to shutdown.")
+                return
+
+            self._reconnect_attempts += 1
             if self._reconnect_attempts >= 2:
                 LOGGER.warning(
                     "Two consecutive WebSocket failures – will wait for next "

--- a/custom_components/livisi/livisi_connector.py
+++ b/custom_components/livisi/livisi_connector.py
@@ -278,8 +278,7 @@ class LivisiConnection:
             LOGGER.debug("Error retrieving token from SHC: %s", error)
             raise LivisiException("Error retrieving token from SHC") from error
         finally:
-            token_preview = self._decode_jwt_payload(self.token)
-            LOGGER.debug("Token retrieval finished, token: %s", token_preview)
+            LOGGER.info("Livisi token retrieval finished, token: %s", self._format_token_info(self.token))
 
     async def _async_refresh_token(self) -> None:
         """Refresh the token if needed, using a lock to prevent concurrent refreshes."""

--- a/custom_components/livisi/livisi_connector.py
+++ b/custom_components/livisi/livisi_connector.py
@@ -245,8 +245,7 @@ class LivisiConnection:
             )
             LOGGER.debug("Updated access token")
             new_token = access_data.get("access_token")
-            new_token_preview = self._format_token_info(new_token)
-            LOGGER.debug("Received token from SHC: %s", new_token_preview)
+            LOGGER.info("Received token from SHC: %s", self._format_token_info(new_token))
             self.token = new_token
             if self.token is None:
                 errorcode = access_data.get("errorcode")
@@ -277,8 +276,6 @@ class LivisiConnection:
         except Exception as error:
             LOGGER.debug("Error retrieving token from SHC: %s", error)
             raise LivisiException("Error retrieving token from SHC") from error
-        finally:
-            LOGGER.info("Livisi token retrieval finished, token: %s", self._format_token_info(self.token))
 
     async def _async_refresh_token(self) -> None:
         """Refresh the token if needed, using a lock to prevent concurrent refreshes."""
@@ -287,11 +284,10 @@ class LivisiConnection:
         expired_token = self.token
 
         async with self._token_refresh_lock:
-            # Check if token is still the same expired one
-            if self.token != None and self.token == expired_token:
+            # Check if token needs to be refreshed
+            if self.token is None or self.token == expired_token:
                 LOGGER.info(
-                    "Livisi token %s expired, requesting new token from SHC",
-                    self._format_token_info(self.token)
+                    "Livisi token %s is missing or expired, requesting new token from SHC" , self._format_token_info(self.token)
                 )
                 try:
                     await self._async_retrieve_token()

--- a/custom_components/livisi/livisi_connector.py
+++ b/custom_components/livisi/livisi_connector.py
@@ -352,7 +352,7 @@ class LivisiConnection:
             errorcode = response.get("errorcode")
             # Handle expired token (2007)
             if errorcode == 2007:
-                LOGGER.debug("Livisi token %s expired (error 2007)", self.token)
+                LOGGER.debug("Livisi token %s expired (error 2007)", self._format_token_info(self.token))
                 await self._async_refresh_token()
                 
                 # Retry the original request with the (possibly new) token

--- a/custom_components/livisi/livisi_connector.py
+++ b/custom_components/livisi/livisi_connector.py
@@ -199,6 +199,8 @@ class LivisiConnection:
                 LOGGER.debug("Token expired, requesting new token")
                 try:
                     await self._async_retrieve_token()
+                    # Wait a bit before retrying to avoid SHC being overwhelmed
+                    await asyncio.sleep(0.5)
                     response = await self._async_send_request(method, url, payload, headers)
                 except Exception:
                     # Reset token to trigger reauthentication on next request

--- a/custom_components/livisi/livisi_connector.py
+++ b/custom_components/livisi/livisi_connector.py
@@ -209,7 +209,7 @@ class LivisiConnection:
 
                 try:
                     await self._async_refresh_token()
-                except Exception:
+                except Exception as e:
                     LOGGER.error("Unhandled error requesting token", exc_info=e)  
                     raise
 

--- a/custom_components/livisi/livisi_connector.py
+++ b/custom_components/livisi/livisi_connector.py
@@ -322,8 +322,21 @@ class LivisiConnection:
         # Check if the token is expired (not sure if this works on V1 SHC, so keep the old 2007 refresh code below too)
         token_payload = self._decode_jwt_payload(self.token)
         if token_payload:
+            preview = self._format_token_info(self.token)
+            LOGGER.debug("Livisi token %s", preview)
+
             expires = token_payload.get("exp", 0)
-            if expires > 0 and time.time() >= expires:
+            age = time.time() - token_payload.get("iat", 0)
+            # fordebug purposes, request if age > 2 minutes 
+            
+            if age > 120:
+                LOGGER.debug(
+                    "Livisi token %s is %s old, requesting new token from SHC",
+                    self.token,
+                    time.strftime("%Hh %Mm %Ss", time.gmtime(age)),
+                )
+
+            if age > 123 or (expires > 0 and time.time() >= expires):
                 LOGGER.debug("Livisi token %s detected as expired", self.token)
                 # Token is expired, we need to refresh it
                 try:


### PR DESCRIPTION
## Summary
- trigger token expiry from exp date in JQT not from 2007 error from SHC (if supported)
- clear token before requesting a new none
- reset token to `None` when refresh fails so next update retries
- prevent concurrent token requests
