### PR TITLE
Use runtime data in config entry

### DIFF
--- a/custom_components/livisi/__init__.py
+++ b/custom_components/livisi/__init__.py
@@ -6,7 +6,6 @@ from typing import Final
 
 from homeassistant import core
 from homeassistant.exceptions import ConfigEntryNotReady, ConfigEntryAuthFailed
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
 
@@ -17,7 +16,7 @@ from .livisi_errors import WrongCredentialException
 
 
 from .const import CONF_HOST, DOMAIN, LOGGER, SWITCH_DEVICE_TYPES
-from .coordinator import LivisiDataUpdateCoordinator
+from .coordinator import LivisiConfigEntry, LivisiDataUpdateCoordinator
 
 
 PLATFORMS: Final = [
@@ -34,7 +33,7 @@ PLATFORMS: Final = [
 ]
 
 
-async def async_setup_entry(hass: core.HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: core.HomeAssistant, entry: LivisiConfigEntry) -> bool:
     """Set up Livisi Smart Home from a config entry."""
     coordinator = LivisiDataUpdateCoordinator(hass, entry)
     try:
@@ -46,7 +45,7 @@ async def async_setup_entry(hass: core.HomeAssistant, entry: ConfigEntry) -> boo
         LOGGER.error(exception, exc_info=True)
         raise ConfigEntryNotReady(exception) from exception
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
     device_registry = dr.async_get(hass)
     entity_registry = er.async_get(hass)
     controller = coordinator.aiolivisi.controller
@@ -88,21 +87,17 @@ async def async_setup_entry(hass: core.HomeAssistant, entry: ConfigEntry) -> boo
             if len(entities) == 0:
                 device_registry.async_remove_device(device_entry.id)
 
+    async def close_coordinator() -> None:
+        coordinator.shutdown = True
+        await coordinator.aiolivisi.close()
+
+    entry.async_on_unload(close_coordinator)
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: LivisiConfigEntry) -> bool:
     """Unload a config entry."""
-    coordinator: LivisiDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
-
-    unload_success = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    coordinator.shutdown = True
-    await coordinator.aiolivisi.close()
-
-    if unload_success:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_success
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 async def async_migrate_entry(hass, config_entry):

--- a/custom_components/livisi/binary_sensor.py
+++ b/custom_components/livisi/binary_sensor.py
@@ -9,7 +9,6 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -35,17 +34,17 @@ from .const import (
     WDS_DEVICE_TYPES,
     SMOKE_DETECTOR_DEVICE_TYPES,
 )
-from .coordinator import LivisiDataUpdateCoordinator
+from .coordinator import LivisiConfigEntry, LivisiDataUpdateCoordinator
 from .entity import LivisiEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: LivisiConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up binary_sensor device."""
-    coordinator: LivisiDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator: LivisiDataUpdateCoordinator = config_entry.runtime_data
     known_devices = set()
 
     @callback
@@ -127,7 +126,7 @@ class LivisiBinarySensor(LivisiEntity, BinarySensorEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: LivisiConfigEntry,
         coordinator: LivisiDataUpdateCoordinator,
         device: LivisiDevice,
         entity_desc: BinarySensorEntityDescription,
@@ -185,7 +184,7 @@ class LivisiBatteryLowSensor(LivisiEntity, BinarySensorEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: LivisiConfigEntry,
         coordinator: LivisiDataUpdateCoordinator,
         device: LivisiDevice,
     ) -> None:
@@ -219,7 +218,7 @@ class LivisiMotionSensor(LivisiEntity, BinarySensorEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: LivisiConfigEntry,
         coordinator: LivisiDataUpdateCoordinator,
         device: LivisiDevice,
         entity_desc: BinarySensorEntityDescription,

--- a/custom_components/livisi/button.py
+++ b/custom_components/livisi/button.py
@@ -7,7 +7,6 @@ from homeassistant.components.button import (
     ButtonDeviceClass,
     ButtonEntityDescription,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -21,17 +20,17 @@ from custom_components.livisi.livisi_const import (
 from .livisi_device import LivisiDevice
 
 from .const import DOMAIN, LOGGER
-from .coordinator import LivisiDataUpdateCoordinator
+from .coordinator import LivisiConfigEntry, LivisiDataUpdateCoordinator
 from .entity import LivisiEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: LivisiConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up button devices."""
-    coordinator: LivisiDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator: LivisiDataUpdateCoordinator = config_entry.runtime_data
     known_devices = set()
 
     @callback
@@ -70,7 +69,7 @@ class LivisiButton(LivisiEntity, ButtonEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: LivisiConfigEntry,
         coordinator: LivisiDataUpdateCoordinator,
         device: LivisiDevice,
         entity_desc: ButtonEntityDescription,

--- a/custom_components/livisi/climate.py
+++ b/custom_components/livisi/climate.py
@@ -10,7 +10,6 @@ from homeassistant.components.climate import (
     HVACAction,
     HVACMode,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
@@ -20,7 +19,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .livisi_device import LivisiDevice
 
 from .const import (
-    DOMAIN,
     HUMIDITY,
     LIVISI_STATE_CHANGE,
     LOGGER,
@@ -33,17 +31,17 @@ from .const import (
     VRCC_DEVICE_TYPES,
 )
 
-from .coordinator import LivisiDataUpdateCoordinator
+from .coordinator import LivisiConfigEntry, LivisiDataUpdateCoordinator
 from .entity import LivisiEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: LivisiConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up climate device."""
-    coordinator: LivisiDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator: LivisiDataUpdateCoordinator = config_entry.runtime_data
     known_devices = set()
 
     @callback
@@ -80,7 +78,7 @@ class LivisiClimate(LivisiEntity, ClimateEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: LivisiConfigEntry,
         coordinator: LivisiDataUpdateCoordinator,
         device: LivisiDevice,
     ) -> None:

--- a/custom_components/livisi/coordinator.py
+++ b/custom_components/livisi/coordinator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import timedelta
-from typing import Any
+from typing import Any, TypeAlias
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -256,3 +256,6 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[LivisiDevice]]):
 
             LOGGER.info("Retrying Livisi WebSocket connection shortly…")
             await asyncio.sleep(0.2)
+
+
+LivisiConfigEntry: TypeAlias = ConfigEntry[LivisiDataUpdateCoordinator]

--- a/custom_components/livisi/cover.py
+++ b/custom_components/livisi/cover.py
@@ -10,7 +10,6 @@ from homeassistant.components.cover import (
     CoverEntity,
     CoverEntityFeature,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -19,23 +18,22 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .livisi_device import LivisiDevice
 
 from .const import (
-    DOMAIN,
     LOGGER,
     LIVISI_STATE_CHANGE,
     SHUTTER_DEVICE_TYPES,
     SHUTTER_LEVEL,
 )
-from .coordinator import LivisiDataUpdateCoordinator
+from .coordinator import LivisiConfigEntry, LivisiDataUpdateCoordinator
 from .entity import LivisiEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: LivisiConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up switch device."""
-    coordinator: LivisiDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator: LivisiDataUpdateCoordinator = config_entry.runtime_data
     known_devices = set()
 
     @callback
@@ -67,7 +65,7 @@ class LivisiShutter(LivisiEntity, CoverEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: LivisiConfigEntry,
         coordinator: LivisiDataUpdateCoordinator,
         device: dict[str, Any],
     ) -> None:

--- a/custom_components/livisi/entity.py
+++ b/custom_components/livisi/entity.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import DeviceInfo
@@ -14,7 +13,7 @@ from homeassistant.components.binary_sensor import BinarySensorEntity
 from .livisi_device import LivisiDevice
 
 from .const import CONF_HOST, DOMAIN, LOGGER, LIVISI_REACHABILITY_CHANGE
-from .coordinator import LivisiDataUpdateCoordinator
+from .coordinator import LivisiConfigEntry, LivisiDataUpdateCoordinator
 
 
 def create_device_info(config_entry, device, device_name=None):
@@ -42,7 +41,7 @@ class LivisiEntity(CoordinatorEntity[LivisiDataUpdateCoordinator]):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: LivisiConfigEntry,
         coordinator: LivisiDataUpdateCoordinator,
         device: LivisiDevice,
         capability_name: str = None,

--- a/custom_components/livisi/event.py
+++ b/custom_components/livisi/event.py
@@ -7,7 +7,6 @@ from homeassistant.components.event import (
     EventEntityDescription,
     EventDeviceClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -15,7 +14,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .livisi_device import LivisiDevice
 
 from .const import (
-    DOMAIN,
     LOGGER,
     BUTTON_DEVICE_TYPES,
     MOTION_DEVICE_TYPES,
@@ -23,17 +21,17 @@ from .const import (
     EVENT_MOTION_DETECTED,
     EVENT_BUTTON_PRESSED,
 )
-from .coordinator import LivisiDataUpdateCoordinator
+from .coordinator import LivisiConfigEntry, LivisiDataUpdateCoordinator
 from .entity import LivisiEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: LivisiConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up event device."""
-    coordinator: LivisiDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator: LivisiDataUpdateCoordinator = config_entry.runtime_data
     known_devices = set()
 
     @callback
@@ -89,7 +87,7 @@ class LivisiEvent(LivisiEntity, EventEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: LivisiConfigEntry,
         coordinator: LivisiDataUpdateCoordinator,
         device: LivisiDevice,
         entity_desc: EventEntityDescription,

--- a/custom_components/livisi/light.py
+++ b/custom_components/livisi/light.py
@@ -6,7 +6,6 @@ from typing import Any
 from decimal import Decimal
 
 from homeassistant.components.light import LightEntity, ColorMode, ATTR_BRIGHTNESS
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -16,24 +15,23 @@ from .livisi_device import LivisiDevice
 
 from .const import (
     DIM_LEVEL,
-    DOMAIN,
     LIVISI_STATE_CHANGE,
     LOGGER,
     ON_STATE,
     SWITCH_DEVICE_TYPES,
     DIMMING_DEVICE_TYPES,
 )
-from .coordinator import LivisiDataUpdateCoordinator
+from .coordinator import LivisiConfigEntry, LivisiDataUpdateCoordinator
 from .entity import LivisiEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: LivisiConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up light device."""
-    coordinator: LivisiDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator: LivisiDataUpdateCoordinator = config_entry.runtime_data
     known_devices = set()
 
     @callback
@@ -79,7 +77,7 @@ class LivisiSwitchLight(LivisiEntity, LightEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: LivisiConfigEntry,
         coordinator: LivisiDataUpdateCoordinator,
         device: LivisiDevice,
         capability_id: str,
@@ -158,7 +156,7 @@ class LivisiDimmerLight(LivisiEntity, LightEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: LivisiConfigEntry,
         coordinator: LivisiDataUpdateCoordinator,
         device: LivisiDevice,
         capability_id: str,

--- a/custom_components/livisi/number.py
+++ b/custom_components/livisi/number.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.components.number import RestoreNumber
 
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -15,17 +14,17 @@ from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
 from .entity import create_device_info
 from .livisi_device import LivisiDevice
 
-from .const import DOMAIN, LOGGER, MOTION_DEVICE_TYPES
-from .coordinator import LivisiDataUpdateCoordinator
+from .const import LOGGER, MOTION_DEVICE_TYPES
+from .coordinator import LivisiConfigEntry, LivisiDataUpdateCoordinator
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: LivisiConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up number entities."""
-    coordinator: LivisiDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator: LivisiDataUpdateCoordinator = config_entry.runtime_data
     known_devices = set()
 
     @callback
@@ -72,7 +71,7 @@ class NoopConfigNumber(RestoreNumber):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: LivisiConfigEntry,
         device: LivisiDevice,
         entity_desc: NumberEntityDescription,
     ) -> None:

--- a/custom_components/livisi/sensor.py
+++ b/custom_components/livisi/sensor.py
@@ -9,7 +9,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
 from homeassistant.components.sensor.const import SensorDeviceClass, SensorStateClass
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
     LIGHT_LUX,
@@ -50,7 +49,7 @@ from .const import (
     VRCC_DEVICE_TYPES,
     POWER_CONSUMPTION,
 )
-from .coordinator import LivisiDataUpdateCoordinator
+from .coordinator import LivisiConfigEntry, LivisiDataUpdateCoordinator
 from .entity import LivisiEntity
 
 CONTROLLER_SENSORS = {
@@ -227,11 +226,11 @@ CAPABILITY_SENSORS = {
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: LivisiConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up binary_sensor device."""
-    coordinator: LivisiDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator: LivisiDataUpdateCoordinator = config_entry.runtime_data
     known_devices = set()
 
     @callback
@@ -294,7 +293,7 @@ class LivisiSensor(LivisiEntity, SensorEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: LivisiConfigEntry,
         coordinator: LivisiDataUpdateCoordinator,
         device: LivisiDevice,
         entity_desc: SensorEntityDescription,
@@ -388,7 +387,7 @@ class LivisiControllerSensor(LivisiEntity, SensorEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: LivisiConfigEntry,
         coordinator: LivisiDataUpdateCoordinator,
         device: LivisiDevice,
         entity_desc: SensorEntityDescription,

--- a/custom_components/livisi/siren.py
+++ b/custom_components/livisi/siren.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from homeassistant.components.siren import SirenEntity
 from homeassistant.components.siren.const import SirenEntityFeature
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -16,24 +15,23 @@ from .livisi_device import LivisiDevice
 
 from .const import (
     ACTIVE_CHANNEL,
-    DOMAIN,
     LIVISI_STATE_CHANGE,
     LOGGER,
     ON_STATE,
     SMOKE_DETECTOR_DEVICE_TYPES,
     SIREN_DEVICE_TYPES,
 )
-from .coordinator import LivisiDataUpdateCoordinator
+from .coordinator import LivisiConfigEntry, LivisiDataUpdateCoordinator
 from .entity import LivisiEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: LivisiConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up a smoke detecor device."""
-    coordinator: LivisiDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator: LivisiDataUpdateCoordinator = config_entry.runtime_data
     known_devices = set()
 
     @callback
@@ -77,7 +75,7 @@ class LivisiSmoke(LivisiEntity, SirenEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: LivisiConfigEntry,
         coordinator: LivisiDataUpdateCoordinator,
         device: LivisiDevice,
     ) -> None:
@@ -152,7 +150,7 @@ class LivisiSiren(LivisiEntity, SirenEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: LivisiConfigEntry,
         coordinator: LivisiDataUpdateCoordinator,
         device: LivisiDevice,
     ) -> None:

--- a/custom_components/livisi/switch.py
+++ b/custom_components/livisi/switch.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -14,7 +13,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .livisi_device import LivisiDevice
 
 from .const import (
-    DOMAIN,
     LIVISI_STATE_CHANGE,
     LOGGER,
     ON_STATE,
@@ -22,17 +20,17 @@ from .const import (
     VALUE,
     VARIABLE_DEVICE_TYPES,
 )
-from .coordinator import LivisiDataUpdateCoordinator
+from .coordinator import LivisiConfigEntry, LivisiDataUpdateCoordinator
 from .entity import LivisiEntity
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: LivisiConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up switch device."""
-    coordinator: LivisiDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator: LivisiDataUpdateCoordinator = config_entry.runtime_data
     known_devices = set()
 
     @callback
@@ -70,7 +68,7 @@ class LivisiSwitch(LivisiEntity, SwitchEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: LivisiConfigEntry,
         coordinator: LivisiDataUpdateCoordinator,
         device: LivisiDevice,
     ) -> None:
@@ -145,7 +143,7 @@ class LivisiVariable(LivisiEntity, SwitchEntity):
 
     def __init__(
         self,
-        config_entry: ConfigEntry,
+        config_entry: LivisiConfigEntry,
         coordinator: LivisiDataUpdateCoordinator,
         device: LivisiDevice,
     ) -> None:


### PR DESCRIPTION
## Summary
- support runtime data on ConfigEntry for coordinator
- update modules to use LivisiConfigEntry

## Testing
- `scripts/lint`

------
https://chatgpt.com/codex/tasks/task_b_68594e6f32b883249c7da843868d6072