### PR TITLE
Add dual-host failover and reconfigure support

### DIFF
--- a/custom_components/livisi/__init__.py
+++ b/custom_components/livisi/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.helpers import entity_registry as er
 from livisi import WrongCredentialException
 
 
-from .const import CONF_HOST, DOMAIN, LOGGER, SWITCH_DEVICE_TYPES
+from .const import DOMAIN, LOGGER, SWITCH_DEVICE_TYPES
 from .coordinator import LivisiConfigEntry, LivisiDataUpdateCoordinator
 
 
@@ -56,7 +56,7 @@ async def async_setup_entry(hass: core.HomeAssistant, entry: LivisiConfigEntry) 
         sw_version=controller.os_version,
         manufacturer="Livisi",
         name=f"SHC {controller.controller_type} {controller.serial_number}",
-        configuration_url=f"http://{entry.data[CONF_HOST]}",
+        configuration_url=f"http://{coordinator.active_host}",
     )
     # The internal device registry UUID of the SHC hub. via_device_id must
     # reference this registered device id (not a (DOMAIN, ...) identifier tuple).
@@ -73,7 +73,7 @@ async def async_setup_entry(hass: core.HomeAssistant, entry: LivisiConfigEntry) 
         "Livisi Smart Home Controller %s %s (%s) connected successfully",
         controller.controller_type,
         controller.os_version,
-        entry.data[CONF_HOST],
+        coordinator.active_host,
     )
     LOGGER.debug(coordinator.data)
 

--- a/custom_components/livisi/config_flow.py
+++ b/custom_components/livisi/config_flow.py
@@ -38,6 +38,59 @@ class LivisiFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, str] | None = None
+    ) -> FlowResult:
+        """Handle reconfiguration of an existing entry (e.g. to add a secondary host)."""
+        entry = self._get_reconfigure_entry()
+
+        if user_input is None:
+            schema = self._reconfigure_schema(entry.data)
+            return self.async_show_form(
+                step_id="reconfigure", data_schema=schema
+            )
+
+        errors = {}
+        host_secondary = user_input.get(CONF_HOST_SECONDARY) or None
+        try:
+            self.aio_livisi = await self._try_connect(
+                user_input[CONF_HOST], host_secondary, user_input[CONF_PASSWORD]
+            )
+        except WrongCredentialException:
+            errors["base"] = "wrong_password"
+        except IncorrectIpAddressException:
+            errors["base"] = "wrong_ip_address"
+        except (ShcUnreachableException, ErrorCodeException):
+            errors["base"] = "cannot_connect"
+        else:
+            await self.aio_livisi.close()
+            data = {
+                CONF_HOST: user_input[CONF_HOST],
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+            }
+            if host_secondary:
+                data[CONF_HOST_SECONDARY] = host_secondary
+            return self.async_update_reload_and_abort(entry, data=data)
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self._reconfigure_schema(user_input),
+            errors=errors,
+        )
+
+    def _reconfigure_schema(self, current: dict) -> vol.Schema:
+        """Build the reconfigure form schema pre-filled with current values."""
+        return vol.Schema(
+            {
+                vol.Required(CONF_HOST, default=current.get(CONF_HOST, "")): str,
+                vol.Required(CONF_PASSWORD, default=current.get(CONF_PASSWORD, "")): str,
+                vol.Optional(
+                    CONF_HOST_SECONDARY,
+                    default=current.get(CONF_HOST_SECONDARY, ""),
+                ): str,
+            }
+        )
+
     async def async_step_reauth(
         self, user_input: dict[str, str] | None = None
     ) -> FlowResult:

--- a/custom_components/livisi/config_flow.py
+++ b/custom_components/livisi/config_flow.py
@@ -135,50 +135,6 @@ class LivisiFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user", data_schema=self.data_schema, errors=errors
         )
 
-    async def async_step_reconfigure(
-        self, user_input: dict[str, str] | None = None
-    ) -> FlowResult:
-        """Handle reconfiguration of an existing entry (e.g. changed IP)."""
-        entry = self._get_reconfigure_entry()
-        reconfigure_schema = vol.Schema(
-            {
-                vol.Required(CONF_HOST, default=entry.data[CONF_HOST]): str,
-                vol.Required(
-                    CONF_PASSWORD, default=entry.data.get(CONF_PASSWORD, "")
-                ): str,
-            }
-        )
-
-        errors = {}
-        if user_input is not None:
-            try:
-                self.aio_livisi = await livisi_connect(
-                    user_input[CONF_HOST], user_input[CONF_PASSWORD]
-                )
-            except WrongCredentialException:
-                errors["base"] = "wrong_password"
-            except ShcUnreachableException:
-                errors["base"] = "cannot_connect"
-            except IncorrectIpAddressException:
-                errors["base"] = "wrong_ip_address"
-            except ErrorCodeException:
-                errors["base"] = "cannot_connect"
-            else:
-                try:
-                    if self.aio_livisi.controller:
-                        return self.async_update_reload_and_abort(
-                            entry, data_updates=user_input
-                        )
-                finally:
-                    await self.aio_livisi.close()
-
-                errors["base"] = "cannot_connect"
-
-        return self.async_show_form(
-            step_id="reconfigure",
-            data_schema=reconfigure_schema,
-            errors=errors,
-        )
     async def _try_connect(
         self, host: str, host_secondary: str | None, password: str
     ) -> LivisiConnection:

--- a/custom_components/livisi/config_flow.py
+++ b/custom_components/livisi/config_flow.py
@@ -8,7 +8,6 @@ from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResult
 
 from livisi import LivisiController
-
 from livisi import LivisiConnection, connect as livisi_connect
 from livisi import (
     ErrorCodeException,
@@ -17,7 +16,10 @@ from livisi import (
     ShcUnreachableException,
 )
 
-from .const import CONF_HOST, CONF_PASSWORD, DOMAIN, LOGGER
+from .const import CONF_HOST, CONF_HOST_SECONDARY, CONF_PASSWORD, DOMAIN, LOGGER
+
+# Exceptions that indicate a network/connectivity problem (not auth)
+_CONNECT_ERRORS = (ShcUnreachableException, IncorrectIpAddressException, ErrorCodeException)
 
 
 class LivisiFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -32,6 +34,7 @@ class LivisiFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 vol.Required(CONF_HOST): str,
                 vol.Required(CONF_PASSWORD): str,
+                vol.Optional(CONF_HOST_SECONDARY): str,
             }
         )
 
@@ -49,24 +52,27 @@ class LivisiFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_show_form(step_id="user", data_schema=self.data_schema)
 
         errors = {}
+        host_secondary = user_input.get(CONF_HOST_SECONDARY) or None
         try:
-            self.aio_livisi = await livisi_connect(
-                user_input[CONF_HOST], user_input[CONF_PASSWORD]
+            self.aio_livisi = await self._try_connect(
+                user_input[CONF_HOST], host_secondary, user_input[CONF_PASSWORD]
             )
         except WrongCredentialException:
             errors["base"] = "wrong_password"
-        except ShcUnreachableException:
-            errors["base"] = "cannot_connect"
         except IncorrectIpAddressException:
             errors["base"] = "wrong_ip_address"
-        except ErrorCodeException:
+        except (ShcUnreachableException, ErrorCodeException):
             errors["base"] = "cannot_connect"
         else:
             try:
                 if self.aio_livisi.controller:
-                    return await self.create_entity(
-                        user_input, self.aio_livisi.controller
-                    )
+                    data = {
+                        CONF_HOST: user_input[CONF_HOST],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    }
+                    if host_secondary:
+                        data[CONF_HOST_SECONDARY] = host_secondary
+                    return await self.create_entity(data, self.aio_livisi.controller)
             finally:
                 await self.aio_livisi.close()
 
@@ -120,6 +126,40 @@ class LivisiFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=reconfigure_schema,
             errors=errors,
         )
+    async def _try_connect(
+        self, host: str, host_secondary: str | None, password: str
+    ) -> LivisiConnection:
+        """Try connecting to primary host, then secondary if primary fails."""
+        try:
+            return await livisi_connect(host, password)
+        except WrongCredentialException:
+            raise
+        except _CONNECT_ERRORS as exc:
+            if host_secondary is None:
+                raise
+            LOGGER.debug(
+                "Primary host %s unreachable during config flow, trying secondary %s: %s",
+                host,
+                host_secondary,
+                exc,
+            )
+
+        # Primary failed with connectivity error — try secondary
+        try:
+            conn = await livisi_connect(host_secondary, password)
+            LOGGER.info(
+                "Config flow: connected via secondary host %s (primary %s unreachable)",
+                host_secondary,
+                host,
+            )
+            return conn
+        except WrongCredentialException:
+            raise
+        except _CONNECT_ERRORS as exc:
+            # Both hosts failed — raise a generic ShcUnreachableException
+            raise ShcUnreachableException(
+                f"Neither {host} nor {host_secondary} is reachable."
+            ) from exc
 
     async def create_entity(
         self, user_input: dict[str, str], controller: LivisiController

--- a/custom_components/livisi/const.py
+++ b/custom_components/livisi/const.py
@@ -9,6 +9,7 @@ DOMAIN = "livisi"
 LIVISI_EVENT = f"{DOMAIN}_event"
 
 CONF_HOST = "host"
+CONF_HOST_SECONDARY: Final = "host_secondary"
 CONF_PASSWORD: Final = "password"
 
 CONF_SUBTYPE: Final = "subtype"

--- a/custom_components/livisi/coordinator.py
+++ b/custom_components/livisi/coordinator.py
@@ -12,13 +12,18 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from livisi import LivisiDevice
-from livisi import LivisiConnection, connect as livisi_connect
-from livisi import LivisiWebsocketEvent
 from livisi import (
+    IS_REACHABLE,
+    LivisiConnection,
+    LivisiDevice,
+    LivisiWebsocketEvent,
+    LIVISI_EVENT_BUTTON_PRESSED,
+    LIVISI_EVENT_MOTION_DETECTED,
+    LIVISI_EVENT_STATE_CHANGED,
     WrongCredentialException,
     ShcUnreachableException,
     IncorrectIpAddressException,
+    connect as livisi_connect,
 )
 from .const import (
     CONF_HOST,
@@ -33,19 +38,12 @@ from .const import (
     DEVICE_POLLING_DELAY,
     STATE_PROPERTIES,
 )
-from livisi import (
-    LIVISI_EVENT_BUTTON_PRESSED,
-    LIVISI_EVENT_MOTION_DETECTED,
-    LIVISI_EVENT_STATE_CHANGED,
-    IS_REACHABLE,
-)
 
 
 class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[LivisiDevice]]):
     """Manage polling plus WebSocket push updates for Livisi."""
 
     config_entry: ConfigEntry
-    aiolivisi: LivisiConnection
 
     def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
         """Initialize the coordinator."""
@@ -66,6 +64,7 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[LivisiDevice]]):
         self._controller_device_id: str | None = None
         # Internal device registry UUID of the SHC hub, set during async_setup_entry.
         self.controller_registry_id: str | None = None
+        self.aiolivisi: LivisiConnection | None = None
         self.active_host: str = config_entry.data[CONF_HOST]
         self._reconnecting: bool = False  # guard against re-entry in reconnect
         self._ws_generation: int = 0  # incremented each time ws_connect() is called
@@ -81,9 +80,10 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[LivisiDevice]]):
     # ---------------------------------------------------------------------
     # Failover connection logic
     # ---------------------------------------------------------------------
-    async def _connect_any(self, prefer_primary: bool = True) -> None:
+    async def _connect_any(self) -> None:
         """Try connecting to primary host, then secondary (if configured).
 
+        Always tries primary first (prefer-primary policy).
         Sets self.active_host and self.aiolivisi on success.
         Raises WrongCredentialException immediately on auth failure.
         Raises the last connectivity exception if all hosts are exhausted.
@@ -164,23 +164,35 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[LivisiDevice]]):
                 pass
             self.websocket_connected = False
 
-            await self._connect_any(prefer_primary=True)
+            try:
+                await self._connect_any()
+            except WrongCredentialException as exc:
+                raise ConfigEntryAuthFailed(
+                    "Authentication failed, please reconfigure."
+                ) from exc
+            except Exception as exc:
+                LOGGER.error(
+                    "Livisi: reconnect failed — all hosts unreachable: %s", exc
+                )
+                self._mark_controller_unreachable()
+                self._recover_from_error = True
+                raise UpdateFailed(exc) from exc
+
             LOGGER.info(
                 "Livisi: reconnect successful on %s, retrying update",
                 self.active_host,
             )
-            return await self.async_get_devices()
-        except WrongCredentialException as exc:
-            raise ConfigEntryAuthFailed(
-                "Authentication failed, please reconfigure."
-            ) from exc
-        except Exception as exc:
-            LOGGER.error(
-                "Livisi: reconnect failed (tried all hosts): %s", exc
-            )
-            self._mark_controller_unreachable()
-            self._recover_from_error = True
-            raise UpdateFailed(exc) from exc
+            try:
+                return await self.async_get_devices()
+            except Exception as exc:
+                LOGGER.error(
+                    "Livisi: update failed after reconnect to %s: %s",
+                    self.active_host,
+                    exc,
+                )
+                self._mark_controller_unreachable()
+                self._recover_from_error = True
+                raise UpdateFailed(exc) from exc
         finally:
             self._reconnecting = False
 
@@ -313,6 +325,7 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[LivisiDevice]]):
     async def ws_connect(self) -> None:
         """Create the background task that runs the WebSocket loop."""
         self._ws_generation += 1
+        self._reconnect_attempts = 0  # fresh loop gets full quota of retries
         self.config_entry.async_create_background_task(
             self.hass, self.ws_loop(), name="livisi_ws"
         )

--- a/custom_components/livisi/coordinator.py
+++ b/custom_components/livisi/coordinator.py
@@ -8,14 +8,21 @@ from typing import Any, TypeAlias
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from livisi import LivisiDevice
 from livisi import LivisiConnection, connect as livisi_connect
 from livisi import LivisiWebsocketEvent
+from livisi import (
+    WrongCredentialException,
+    ShcUnreachableException,
+    IncorrectIpAddressException,
+)
 from .const import (
     CONF_HOST,
+    CONF_HOST_SECONDARY,
     CONF_PASSWORD,
     EVENT_BUTTON_PRESSED,
     EVENT_MOTION_DETECTED,
@@ -59,47 +66,146 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[LivisiDevice]]):
         self._controller_device_id: str | None = None
         # Internal device registry UUID of the SHC hub, set during async_setup_entry.
         self.controller_registry_id: str | None = None
+        self.active_host: str = config_entry.data[CONF_HOST]
+        self._reconnecting: bool = False  # guard against re-entry in reconnect
+        self._ws_generation: int = 0  # incremented each time ws_connect() is called
 
     # ---------------------------------------------------------------------
     # HA lifecycle
     # ---------------------------------------------------------------------
     async def async_setup(self) -> None:
         """Initialise connection to the Livisi controller."""
-        self.aiolivisi = await livisi_connect(
-            self.config_entry.data[CONF_HOST],
-            self.config_entry.data[CONF_PASSWORD],
-        )
+        await self._connect_any()
         self.shutdown = False
 
+    # ---------------------------------------------------------------------
+    # Failover connection logic
+    # ---------------------------------------------------------------------
+    async def _connect_any(self, prefer_primary: bool = True) -> None:
+        """Try connecting to primary host, then secondary (if configured).
+
+        Sets self.active_host and self.aiolivisi on success.
+        Raises WrongCredentialException immediately on auth failure.
+        Raises the last connectivity exception if all hosts are exhausted.
+        """
+        primary = self.config_entry.data[CONF_HOST]
+        secondary = self.config_entry.data.get(CONF_HOST_SECONDARY)
+
+        hosts: list[str] = [primary]
+        if secondary:
+            hosts.append(secondary)
+
+        last_exc: Exception | None = None
+        for host in hosts:
+            try:
+                connection = await livisi_connect(
+                    host, self.config_entry.data[CONF_PASSWORD]
+                )
+                if self.active_host != host:
+                    LOGGER.info(
+                        "Livisi: switched active host from %s to %s",
+                        self.active_host,
+                        host,
+                    )
+                self.active_host = host
+                self.aiolivisi = connection
+                return
+            except WrongCredentialException:
+                raise  # auth error — do not attempt fallback
+            except Exception as exc:
+                LOGGER.debug("Livisi: cannot connect to %s: %s", host, exc)
+                last_exc = exc
+
+        raise last_exc
+
+    # ---------------------------------------------------------------------
+    # Update logic
+    # ---------------------------------------------------------------------
     async def _async_update_data(self) -> list[LivisiDevice]:
         """Poll the controller for device configuration."""
         try:
             LOGGER.debug("Fetching Livisi data")
             return await self.async_get_devices()
+        except WrongCredentialException as exc:
+            raise ConfigEntryAuthFailed(
+                "Authentication failed, please reconfigure."
+            ) from exc
+        except (ShcUnreachableException, IncorrectIpAddressException) as exc:
+            LOGGER.debug(
+                "Livisi connection lost on %s: %s — attempting host failover",
+                self.active_host,
+                exc,
+            )
+            return await self._reconnect_and_update(exc)
         except Exception as exc:
             LOGGER.error("Error fetching Livisi data: %s", exc)
-            controller_id = self._controller_device_id
-            if controller_id is None and self.data is not None:
-                for device in self.data:
-                    if device.is_shc:
-                        controller_id = device.id
-                        break
-            if controller_id is not None:
-                LOGGER.debug(
-                    "Marking controller %s unreachable due to error",
-                    controller_id,
-                )
-                self._async_dispatcher_send(
-                    LIVISI_REACHABILITY_CHANGE,
-                    controller_id,
-                    False,
-                )
-            else:
-                LOGGER.debug(
-                    "Controller device id unknown, cannot mark unreachable"
-                )
+            self._mark_controller_unreachable()
             self._recover_from_error = True
             raise UpdateFailed(exc) from exc
+
+    async def _reconnect_and_update(
+        self, original_exc: Exception
+    ) -> list[LivisiDevice]:
+        """Attempt host failover then retry the update once.
+
+        At most one reconnect attempt per update cycle (guarded by _reconnecting).
+        """
+        if self._reconnecting:
+            self._mark_controller_unreachable()
+            self._recover_from_error = True
+            raise UpdateFailed(original_exc) from original_exc
+
+        self._reconnecting = True
+        try:
+            # Close the stale connection before reconnecting
+            try:
+                await self.aiolivisi.close()
+            except Exception:
+                pass
+            self.websocket_connected = False
+
+            await self._connect_any(prefer_primary=True)
+            LOGGER.info(
+                "Livisi: reconnect successful on %s, retrying update",
+                self.active_host,
+            )
+            return await self.async_get_devices()
+        except WrongCredentialException as exc:
+            raise ConfigEntryAuthFailed(
+                "Authentication failed, please reconfigure."
+            ) from exc
+        except Exception as exc:
+            LOGGER.error(
+                "Livisi: reconnect failed (tried all hosts): %s", exc
+            )
+            self._mark_controller_unreachable()
+            self._recover_from_error = True
+            raise UpdateFailed(exc) from exc
+        finally:
+            self._reconnecting = False
+
+    def _mark_controller_unreachable(self) -> None:
+        """Send a reachability=False event for the controller device."""
+        controller_id = self._controller_device_id
+        if controller_id is None and self.data is not None:
+            for device in self.data:
+                if device.is_shc:
+                    controller_id = device.id
+                    break
+        if controller_id is not None:
+            LOGGER.debug(
+                "Marking controller %s unreachable due to error",
+                controller_id,
+            )
+            self._async_dispatcher_send(
+                LIVISI_REACHABILITY_CHANGE,
+                controller_id,
+                False,
+            )
+        else:
+            LOGGER.debug(
+                "Controller device id unknown, cannot mark unreachable"
+            )
 
     # ---------------------------------------------------------------------
     # Dispatcher helpers
@@ -206,6 +312,7 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[LivisiDevice]]):
     # ---------------------------------------------------------------------
     async def ws_connect(self) -> None:
         """Create the background task that runs the WebSocket loop."""
+        self._ws_generation += 1
         self.config_entry.async_create_background_task(
             self.hass, self.ws_loop(), name="livisi_ws"
         )
@@ -216,8 +323,21 @@ class LivisiDataUpdateCoordinator(DataUpdateCoordinator[list[LivisiDevice]]):
         * Tries one immediate reconnect after a failure.
         * Stops after two consecutive failures without receiving any data.
         * Next successful poll will schedule a fresh connection.
+        * Exits immediately if a newer ws_connect() call has been made
+          (generation mismatch), avoiding duplicate WebSocket connections
+          after a host failover.
         """
+        generation = self._ws_generation
         while True:
+            # Exit if a newer WebSocket loop has been started (host failover)
+            if generation != self._ws_generation:
+                LOGGER.debug(
+                    "Livisi WebSocket loop (generation %d) superseded, exiting",
+                    generation,
+                )
+                self.websocket_connected = False
+                return
+
             try:
                 LOGGER.info(
                     "Connecting to Livisi WebSocket (consecutive failures: %d)",

--- a/custom_components/livisi/strings.json
+++ b/custom_components/livisi/strings.json
@@ -17,6 +17,14 @@
           "host_secondary": "Secondary IP Address (optional fallback)"
         }
       },
+      "reconfigure": {
+        "description": "Update the IP address(es) and/or password for your SHC. You can add or change the optional secondary (fallback) address here.",
+        "data": {
+          "host": "[%key:common::config_flow::data::ip%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "host_secondary": "Secondary IP Address (optional fallback)"
+        }
+      },
       "reauth": {
         "description": "Please enter the correct SHC password.",
         "data": {

--- a/custom_components/livisi/strings.json
+++ b/custom_components/livisi/strings.json
@@ -5,14 +5,16 @@
         "description": "Enter the IP address and the (local) password of the SHC.",
         "data": {
           "host": "[%key:common::config_flow::data::ip%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "host_secondary": "Secondary IP Address (optional fallback)"
         }
       },
       "init": {
         "description": "Enter the IP address and the (local) password of the SHC.",
         "data": {
           "host": "[%key:common::config_flow::data::ip%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "host_secondary": "Secondary IP Address (optional fallback)"
         }
       },
       "reauth": {

--- a/custom_components/livisi/translations/de.json
+++ b/custom_components/livisi/translations/de.json
@@ -9,14 +9,16 @@
             "user": {
                 "data": {
                     "host": "IP Adresse",
-                    "password": "Passwort"
+                    "password": "Passwort",
+                    "host_secondary": "Sekundäre IP Adresse (optionale Ausweichadresse)"
                 },
                 "description": "Bitte IP Adresse und Passwort zur lokalen Verbindung zum SHC eingeben."
             },
             "init": {
                 "data": {
                     "host": "IP Adresse",
-                    "password": "Passwort"
+                    "password": "Passwort",
+                    "host_secondary": "Sekundäre IP Adresse (optionale Ausweichadresse)"
                 },
                 "description": "Bitte IP Adresse und Passwort zur lokalen Verbindung zum SHC eingeben."
             },

--- a/custom_components/livisi/translations/de.json
+++ b/custom_components/livisi/translations/de.json
@@ -22,6 +22,14 @@
                 },
                 "description": "Bitte IP Adresse und Passwort zur lokalen Verbindung zum SHC eingeben."
             },
+            "reconfigure": {
+                "description": "IP-Adresse(n) und/oder Passwort der SHC aktualisieren. Hier kann auch die optionale Ausweichadresse hinzugefügt oder geändert werden.",
+                "data": {
+                    "host": "IP Adresse",
+                    "password": "Passwort",
+                    "host_secondary": "Sekundäre IP Adresse (optionale Ausweichadresse)"
+                }
+            },
             "reauth": {
                 "description": "Bitte das korrekt SHC Passwort angeben.",
                 "data": {

--- a/custom_components/livisi/translations/en.json
+++ b/custom_components/livisi/translations/en.json
@@ -22,6 +22,14 @@
                 },
                 "description": "Enter the IP address and the (local) password of the SHC."
             },
+            "reconfigure": {
+                "description": "Update the IP address(es) and/or password for your SHC. You can add or change the optional secondary (fallback) address here.",
+                "data": {
+                    "host": "IP Address",
+                    "password": "Password",
+                    "host_secondary": "Secondary IP Address (optional fallback)"
+                }
+            },
             "reauth": {
                 "description": "Please enter the correct SHC password.",
                 "data": {

--- a/custom_components/livisi/translations/en.json
+++ b/custom_components/livisi/translations/en.json
@@ -9,14 +9,16 @@
             "user": {
                 "data": {
                     "host": "IP Address",
-                    "password": "Password"
+                    "password": "Password",
+                    "host_secondary": "Secondary IP Address (optional fallback)"
                 },
                 "description": "Enter the IP address and the (local) password of the SHC."
             },
             "init": {
                 "data": {
                     "host": "IP Address",
-                    "password": "Password"
+                    "password": "Password",
+                    "host_secondary": "Secondary IP Address (optional fallback)"
                 },
                 "description": "Enter the IP address and the (local) password of the SHC."
             },

--- a/hacs.json
+++ b/hacs.json
@@ -1,8 +1,6 @@
 {
     "name": "Livisi Unofficial",
-    "filename": "livisi_unofficial.zip",
     "hide_default_branch": true,
     "homeassistant": "2025.5.0",
-    "render_readme": true,
-    "zip_release": true
+    "render_readme": true
 }


### PR DESCRIPTION
## Problem
The integration currently depends on a single SHC address and changing the controller IP or password requires removing and reinstalling the integration. Reconnect handling can also leave stale connections or inconsistent availability state.

## Changes
- Add an optional secondary SHC address with primary-first connection policy.
- Fail over and reconnect when the active controller becomes unreachable.
- Guard reconnect attempts and WebSocket generations to avoid re-entry and stale callbacks.
- Preserve correct controller device registry relationships for child entities.
- Add a reconfigure flow to update host, optional secondary host, and password without reinstalling.
- Remove the HACS `zip_release` setting that is incompatible with this fork setup.

## Validation
- Python syntax compilation passed.
- `git diff --check` passed.
- No unresolved conflict markers remain.

This PR is based directly on the current `develop` branch and contains the four relevant fixes without the local merge commit.