### PR TITLE
Fix integration version metadata for 2.1.2

### DIFF
--- a/custom_components/livisi/manifest.json
+++ b/custom_components/livisi/manifest.json
@@ -14,5 +14,5 @@
   "requirements": [
     "livisi==1.0.0"
   ],
-  "version": "2.0.1"
+  "version": "2.1.2"
 }


### PR DESCRIPTION
## Problem
The GitHub release/tag `2.1.1` currently contains a `manifest.json` that still reports version `2.0.1`. Home Assistant reads the integration version from that manifest, so installations continue to display `2.0.1` even after updating.

## Change
Update `custom_components/livisi/manifest.json` from `2.0.1` to `2.1.2`.

## Expected result
After this change is released as `2.1.2` and installed by HACS, Home Assistant will display version `2.1.2`.

## Validation
- Manifest validated with `python3 -m json.tool`.
- `git diff --check` passed.

This is intentionally a separate PR containing only the version metadata change.